### PR TITLE
Fix FF scrollbar issue

### DIFF
--- a/src/styles/layout.sss
+++ b/src/styles/layout.sss
@@ -29,6 +29,8 @@
 .layout__content
     flex: 2 0
     display: flex
+    // https://stackoverflow.com/questions/28636832#28639686
+    min-height: 0		
 
 .main
     flex: 5 0 60%


### PR DESCRIPTION
## What does it do?
Added min-height property to layout__content class of the index page.

## Why the change?
Firefox wouldn't display the vertical scrollbar otherwise for the lessons.

## How can this be tested?
Remove and add the property again to notice the difference on Firefox.

## Where to start code review?
cpp-tour/src/styles/layout.sss:32:5

## Relevant tickets?
<Please link any relevant tickets>

## Questions?
<Ask us anything!>

