### PR TITLE
Add integration of lessons

### DIFF
--- a/lessons/default/code.cpp
+++ b/lessons/default/code.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello, world!\n";
+    return 0;
+}

--- a/lessons/default/text.adoc
+++ b/lessons/default/text.adoc
@@ -1,0 +1,18 @@
+= Default
+
+.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean diam augue, viverra at rhoncus at, euismod sit amet turpis. Maecenas tellus elit, vehicula vel est quis, efficitur venenatis turpis. Sed faucibus lacus ac nisl malesuada rhoncus. Cras non urna laoreet, consectetur libero at, pharetra lacus. Curabitur tellus nulla, accumsan quis ex nec, lacinia vulputate quam. Curabitur consequat orci in nulla dignissim, auctor blandit ipsum mollis. Maecenas a lobortis ligula.
+
+.Code Example
+[source, c++]
+---
+int main(int argc, char **argv) {
+    return 0;
+}
+---
+
+.
+The following is code: `int`. More code: `char **argv`. Suspendisse tincidunt felis sit amet pulvinar suscipit. Curabitur sit amet ante rhoncus, interdum enim ac, sodales nibh. Proin mauris diam, iaculis in suscipit vel, aliquet a ante. Quisque sapien felis, finibus at nunc a, lacinia ornare nunc. Fusce sollicitudin suscipit tempor. Mauris vel bibendum ex. Nullam finibus mi ut dui sodales, quis bibendum enim consectetur. Vivamus elementum urna et sem vulputate, vel rutrum ante faucibus. Fusce non nisl interdum, vehicula mi sit amet, imperdiet ex. Morbi dignissim ultrices leo, vitae scelerisque diam malesuada sit amet. Aliquam congue odio ut risus posuere, mollis mattis ante semper. Phasellus id arcu nec turpis egestas semper. Nunc in nisi tincidunt, sodales justo vitae, consectetur enim.
+
+.
+Aenean <b>vestibulum</b>, nisl sed hendrerit eleifend, ipsum nibh facilisis augue, vel facilisis sapien augue eget ante. Mauris sit amet varius elit. Duis et orci rutrum, blandit ligula id, pellentesque arcu. Nam aliquam turpis ac sollicitudin maximus. Ut aliquam justo sed odio rhoncus porttitor. Fusce augue metus, pulvinar sit amet tortor vel, condimentum porta lectus. Donec diam justo, facilisis sed dui sit amet, eleifend pellentesque mauris. Cras quis nunc vitae justo elementum egestas. Sed quis congue sapien. Suspendisse aliquam purus sem, ut tempor lorem dapibus nec. Curabitur at elit fringilla, ultricies dolor quis, iaculis magna.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "main": "index.js",
     "scripts": {
         "test": "ava --verbose",
-        "lint": "eslint . --ext .js --ignore-pattern public",
+        "lint:style": "stylelint src/styles",
+        "lint:js": "eslint . --ext .js --ignore-pattern public",
+        "lint": "npm run lint:style && npm run lint:js",
         "start": "webpack-dev-server",
         "build": "webpack",
         "build:p": "webpack -p",
@@ -20,13 +22,18 @@
     "keywords": [],
     "author": "Douman <douman@gmx.se>",
     "license": "MIT",
+    "dependencies": {
+        "codemirror": "5",
+        "split.js": "^1.3.5"
+    },
     "devDependencies": {
+        "html-loader": "0",
+        "asciidoctor-loader": "0",
         "autoprefixer": "7",
         "ava": "0",
         "babel-core": "6",
         "babel-loader": "7",
         "babel-preset-env": "1",
-        "codemirror": "5",
         "css-loader": "0",
         "eslint": "4",
         "eslint-loader": "1",
@@ -72,8 +79,5 @@
     "browserslist": [
         "Last 2 versions",
         "ie 11"
-    ],
-    "dependencies": {
-        "split.js": "^1.3.5"
-    }
+    ]
 }

--- a/src/js/UI.js
+++ b/src/js/UI.js
@@ -5,6 +5,7 @@ import {toggle_class} from './utils.js'
 import {create_editor} from './editor.js'
 import Split from 'split.js'
 
+const ACTIVE = 'active'
 const HIDDEN = 'hidden'
 const RUNNING = 'running'
 
@@ -37,10 +38,30 @@ export default class UI {
             }
         })
 
+        this.dom.sidebar.addEventListener('click', (event) => {
+            const target = event.target
+
+            if (target.href) {
+                for (let link of target.parentNode.children) {
+                    link.classList.remove(ACTIVE)
+                }
+
+                target.classList.add(ACTIVE)
+            }
+        })
+
+        for (let link of this.dom.sidebar.children) {
+            const hash = link.href.split("#")[1]
+
+            if (hash === location.hash.slice(1)) {
+                link.classList.add(ACTIVE)
+                break
+            }
+        }
+
         this.dom.sidebar_toogle.addEventListener('click', () => this.toogle_sidebar())
 
-        this._run = () => this.run()
-        this.actions.run.addEventListener('click', this._run)
+        this.actions.run.addEventListener('click', () => this.run())
     }
 
     /**
@@ -51,6 +72,9 @@ export default class UI {
      * @returns {Object} Instance of editor.
      */
     create_editor(value) {
+        while (this.dom.editor.lastChild)
+            this.dom.editor.removeChild(this.dom.editor.lastChild)
+
         this.actions.reset.removeEventListener('click', this.editor_reset)
         this.editor_reset = () => this.editor.getDoc().setValue(value)
 

--- a/src/main.js
+++ b/src/main.js
@@ -5,8 +5,16 @@ import UI from './js/UI.js'
 import './styles/main.sss'
 
 window.addEventListener("load", function() {
-    const CODE = "#include <iostream>\n\nint main() {\n\tstd::cout << \"Hello, world!\";\n\treturn 0;\n}"
     const ui = new UI()
 
-    /*const code_editor =*/ ui.create_editor(CODE)
+    function on_hash_change() {
+        const code = window.LESSONS[location.hash.slice(1)]
+        if (code !== undefined) {
+            ui.create_editor(code)
+        }
+    }
+
+    window.addEventListener('hashchange', on_hash_change)
+
+    on_hash_change()
 })

--- a/src/styles/common.sss
+++ b/src/styles/common.sss
@@ -99,3 +99,16 @@ code
 
 .bg-image
     background-size: contain
+
+div.sub_page
+    display: none
+
+    &.default
+        display: block
+
+    &:target
+        display: block
+
+        //.default MUST come before any target
+        & ~ div.default
+            display: none

--- a/src/styles/fonts.sss
+++ b/src/styles/fonts.sss
@@ -12,7 +12,6 @@
         url("../fonts/Merriweather/Merriweather-Bold.ttf")
         format("truetype")
 
-
 @font-face
     font-family: 'Source Sans Pro'
     font-weight: 400

--- a/src/styles/sidebar.sss
+++ b/src/styles/sidebar.sss
@@ -23,6 +23,6 @@
     &:hover
         background: #444
 
-    &:target
+    &.active
         background: teal
 

--- a/src/templates/index.pug
+++ b/src/templates/index.pug
@@ -1,41 +1,58 @@
 include _common.pug
 +head(title="C++ Tour")
+
 -
     const links = [
         { title: "Twitter", href: "https://twitter.com/ArvidGerstmann", img: require('../img/icons/twitter.svg')},
         { title: "Github", href: "https://github.com/Leandros/cpp-tour", img: require('../img/icons/github.svg')},
         { title: "Slack", href: "https://cpplang.now.sh", img: require('../img/icons/slack.svg'), target: "_blank"}
     ]
+    const default_page = {
+        code: require('../../lessons/default/code.cpp'),
+        text: require('../../lessons/default/text.adoc')
+    }
+    const lessons = htmlWebpackPlugin.options.lessons.map((lesson) => {
+        // Return new object to avoid modifying original lessons data
+        return {
+            id: `${lesson.num_str}-${lesson.name.replace(' ', '-')}`,
+            code: require('../../lessons/' + lesson.dir_name + '/code.cpp'),
+            text: require('../../lessons/' + lesson.dir_name + '/text.adoc'),
+            num: lesson.num_str,
+            name: lesson.name
+        }
+    })
+
+    let lessons_code = {
+        '': default_page.code
+    }
+
+    for (lesson of lessons) {
+        lessons_code[lesson.id] = lesson.code
+    }
 
 mixin sidebar_link(id, title)
-    a.sidebar__item(id=id href="#"+id)=title
+    a.sidebar__item(href="#"+id)=title
+
+// Init code data
+script.
+    window.LESSONS = !{JSON.stringify(lessons_code)}
 
 body.layout
     // Page header
     nav.layout__header#header
-        a.layout__header__menu(class=['logo'])="C++ Tour"
+        a.layout__header__menu.logo="C++ Tour"
         div
             each link in links
                 a.bg-image.layout__header__icon(title=link.title, href=link.href, target=link.target, style=`background-image: url('${link.img}')`)
     div.layout__content
         // Content
         div.main#main
-            div.main__content(class=['content'])#left_pane
-                h1.headline="Headline"
-                .subheadline="Subheadline"
-                p.
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean diam augue, viverra at rhoncus at, euismod sit amet turpis. Maecenas tellus elit, vehicula vel est quis, efficitur venenatis turpis. Sed faucibus lacus ac nisl malesuada rhoncus. Cras non urna laoreet, consectetur libero at, pharetra lacus. Curabitur tellus nulla, accumsan quis ex nec, lacinia vulputate quam. Curabitur consequat orci in nulla dignissim, auctor blandit ipsum mollis. Maecenas a lobortis ligula.
-                h2.
-                    Code Example
-                pre.
-                    int main(int argc, char **argv)
-                    {
-                        return 0;
-                    }
-                p.
-                    The following is code: <code>int</code>. More code: <code>char **argv</code>. Suspendisse tincidunt felis sit amet pulvinar suscipit. Curabitur sit amet ante rhoncus, interdum enim ac, sodales nibh. Proin mauris diam, iaculis in suscipit vel, aliquet a ante. Quisque sapien felis, finibus at nunc a, lacinia ornare nunc. Fusce sollicitudin suscipit tempor. Mauris vel bibendum ex. Nullam finibus mi ut dui sodales, quis bibendum enim consectetur. Vivamus elementum urna et sem vulputate, vel rutrum ante faucibus. Fusce non nisl interdum, vehicula mi sit amet, imperdiet ex. Morbi dignissim ultrices leo, vitae scelerisque diam malesuada sit amet. Aliquam congue odio ut risus posuere, mollis mattis ante semper. Phasellus id arcu nec turpis egestas semper. Nunc in nisi tincidunt, sodales justo vitae, consectetur enim.
-                p.
-                    Aenean <b>vestibulum</b>, nisl sed hendrerit eleifend, ipsum nibh facilisis augue, vel facilisis sapien augue eget ante. Mauris sit amet varius elit. Duis et orci rutrum, blandit ligula id, pellentesque arcu. Nam aliquam turpis ac sollicitudin maximus. Ut aliquam justo sed odio rhoncus porttitor. Fusce augue metus, pulvinar sit amet tortor vel, condimentum porta lectus. Donec diam justo, facilisis sed dui sit amet, eleifend pellentesque mauris. Cras quis nunc vitae justo elementum egestas. Sed quis congue sapien. Suspendisse aliquam purus sem, ut tempor lorem dapibus nec. Curabitur at elit fringilla, ultricies dolor quis, iaculis magna.
+            div.main__content.content#left_pane
+                each lesson in lessons
+                    div.sub_page(id=lesson.id)!=lesson.text
+
+                // Defaut page. Must be last.
+                div.sub_page.default!=default_page.text
 
             div.main__compiler#right_pane
                 div.main__compiler__editor#editor
@@ -50,7 +67,7 @@ body.layout
 
     // Sidebar
     div.sidebar#sidebar.hidden
-        +sidebar_link("Introduction", "Introduction")
-        +sidebar_link("0", "Lesson 0: Getting Started")
+        each lesson in lessons
+            +sidebar_link(lesson.id, `${lesson.num}: ${lesson.name}`)
 
     +noscript

--- a/webpack/get_lessons.js
+++ b/webpack/get_lessons.js
@@ -1,0 +1,54 @@
+"use strict"
+
+const fs = require('fs')
+const path = require('path')
+
+const LESSON_DIR = path.normalize(path.join(__dirname, '..', 'lessons'))
+
+/**
+ * Retrieves list of lessons.
+ *
+ * @return {Array} Sorted list of lessons.
+ */
+function get_lessons() {
+    function format_dirs(dir_list) {
+        const result = []
+
+        for (let dir of dir_list) {
+            const full_path = path.join(LESSON_DIR, dir)
+
+            if (!fs.lstatSync(full_path).isDirectory()) {
+                continue
+            }
+
+            const name = path.basename(dir)
+
+            if (name === 'default') {
+                continue
+            }
+
+            //format: num-chapter_part1-chapter_part2
+            let [num_str, ...chapter] = name.split('-')
+            const num = parseFloat(num_str)
+            chapter = chapter.join(' ')
+
+            result.push({
+                num,
+                num_str,
+                name: chapter,
+                dir_name: name
+            })
+        }
+
+        //Ensure ascending order by chapter number.
+        result.sort((left, right) => left.num - right.num)
+
+        return result
+    }
+
+    const dir_list = format_dirs(fs.readdirSync(LESSON_DIR))
+
+    return dir_list
+}
+
+module.exports = get_lessons


### PR DESCRIPTION
Introduces lesson integration for webpack.

Currently it loads lessons from folder `lessons/` and expects format of folder inside as `<numeric order>-<name>`
Inside lesson folder there are expected two files:
* `code.cpp` containing C++ code to extract as raw string.
* `text.adoc` lesson content that will be parsed to HTML.

Lessons can be updated during dev server too (not sure about adding new ones)

There is though existing problem, at least for me, that with lessons integrated any change of JS file triggers error.
Not sure if it is webpack fault or something else.