### PR TITLE
Improve default compiler options and clear output from compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "license": "MIT",
     "dependencies": {
         "codemirror": "5",
+        "ansi_up": "2",
         "split.js": "^1.3.5"
     },
     "devDependencies": {

--- a/src/js/UI.js
+++ b/src/js/UI.js
@@ -3,7 +3,12 @@
 import {compile} from './compiler.js'
 import {toggle_class} from './utils.js'
 import {create_editor} from './editor.js'
+
 import Split from 'split.js'
+import ansi_up from "ansi_up"
+
+const ANSI = new ansi_up()
+ANSI.use_classes = true
 
 const ACTIVE = 'active'
 const HIDDEN = 'hidden'
@@ -130,8 +135,8 @@ export default class UI {
         const content = document.createTextNode(`${output}`)
         const exitcode = document.createTextNode(`Program exited with code ${code}.`)
         if (compiler_output) {
-            const warnings = document.createTextNode(`${compiler_output}`)
-            this.dom.warnings.appendChild(warnings)
+            const compiler_output_html_str = ANSI.ansi_to_html(compiler_output)
+            this.dom.warnings.innerHTML = compiler_output_html_str
         }
 
         this.dom.output.appendChild(content)
@@ -140,9 +145,9 @@ export default class UI {
     }
 
     error(message) {
-        const msg = document.createTextNode(`${message}`)
+        const html_str = ANSI.ansi_to_html(message)
 
-        this.dom.errmsg.appendChild(msg)
+        this.dom.errmsg.innerHTML = html_str
         this.toogle_run()
     }
 

--- a/src/js/compiler.js
+++ b/src/js/compiler.js
@@ -34,10 +34,10 @@ export function compile(request) {
         throw "No code field in request!"
     }
     if (!('compiler' in request)) {
-        request.compiler = 'gcc-head'
+        request.compiler = 'clang-head'
     }
     if (!('options' in request)) {
-        request.options = '-Wall -Wextra'
+        request.options = 'warning,boost-1.65.1-clang-head,c++1z,cpp-pedantic'
     }
 
     const options = {

--- a/src/styles/ansi.sss
+++ b/src/styles/ansi.sss
@@ -1,0 +1,40 @@
+//Intentionally reverse color as Wandbox's compiler returns colors for black terminal
+//But we use white background
+.ansi-bright-white-fg,
+.ansi-white-fg
+    color: black
+
+.ansi-red-fg
+    color: red
+
+.ansi-bright-red-fg
+    color: #d00a0a
+
+.ansi-green-fg
+    color: DarkGreen
+
+.ansi-bright-green-fg
+    color: green
+
+.ansi-blue-fg
+    color: DarkBlue
+
+.ansi-bright-blue-fg
+    color: blue
+
+.ansi-yellow-fg,
+.ansi-bright-yellow-fg
+    color: yellow
+
+.ansi-cyan-fg
+    color: DarkCyan
+
+.ansi-bright-cyan-fg
+    color: Cyan
+
+.ansi-magenta-fg
+    color: DarkMagenta
+
+.ansi-bright-magenta-fg
+    color: magenta
+

--- a/src/styles/layout.sss
+++ b/src/styles/layout.sss
@@ -94,15 +94,15 @@
     overflow: auto
     padding: 1em
 
-#exitcode
-    padding-top: 1em
-    color: #0000007f
-
 #errmsg
-    color: #d00a0a
+    color: red
 
 #warnings
     color: #a22
+
+#exitcode
+    padding-top: 1em
+    color: #0000007f
 
 @media screen and (max-width: 960px)
     .main

--- a/src/styles/main.sss
+++ b/src/styles/main.sss
@@ -3,4 +3,5 @@
 @import './sidebar.sss'
 @import './noscript.sss'
 @import './fonts.sss'
+@import './ansi.sss'
 


### PR DESCRIPTION
## What does it do?
- Switch to use clang by default and use options to enable C++17, warnings and boost.
- Clear compiler output of ASCII colors

## How can this be tested?
Before warnings/errors would be with ASCII symbols
After warnings/errors are clean


